### PR TITLE
Prevent AppImage generation

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "build": {
-    "beforeBuildCommand": "yarn run build",
-    "beforeDevCommand": "yarn run dev",
+    "beforeBuildCommand": "yarn install && yarn run build",
+    "beforeDevCommand": "yarn install && yarn run dev",
     "devPath": "http://localhost:5173",
     "distDir": "../dist",
     "withGlobalTauri": false
@@ -72,7 +72,7 @@
         "fullscreen": false,
         "height": 800,
         "resizable": true,
-        "title": "Athena OS Installer",
+        "title": "AthenaOS Installer",
         "width": 1400,
         "center": true,
         "maximizable": true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -54,7 +54,7 @@
       },
       "resources": [],
       "shortDescription": "",
-      "targets": "all",
+      "targets": ["app", "deb", "dmg"],
       "windows": {
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",
@@ -72,7 +72,7 @@
         "fullscreen": false,
         "height": 800,
         "resizable": true,
-        "title": "AthenaOS Installer",
+        "title": "Athena OS Installer",
         "width": 1400,
         "center": true,
         "maximizable": true


### PR DESCRIPTION
Prevent AppImage generation that can cause an error in Arch Linux during the building.